### PR TITLE
Add "with statement context manager" in ttCollection

### DIFF
--- a/Lib/fontTools/ttLib/ttCollection.py
+++ b/Lib/fontTools/ttLib/ttCollection.py
@@ -35,6 +35,16 @@ class TTCollection(object):
 		for i in range(header.numFonts):
 			font = TTFont(file, fontNumber=i, _tableCache=tableCache, **kwargs)
 			fonts.append(font)
+			
+	def __enter__(self):
+		return self
+	
+	def __exit__(self, type, value, traceback):
+		self.close()
+		
+	def close(self):
+		for font in self.fonts:
+			font.close()
 
 	def save(self, file, shareTables=True):
 		"""Save the font to disk. Similarly to the constructor,


### PR DESCRIPTION
In ttCollection, I add "with statement context manager" like ttFont, so we can use ttCollection just like ttFont:
```
with TTCollection(font_path) as font:
    pass
```